### PR TITLE
Added initial scout suite exception file.

### DIFF
--- a/ifit-exceptions.js
+++ b/ifit-exceptions.js
@@ -1,0 +1,28 @@
+exceptions =
+{
+    "elb": {
+        "elb-listener-allowing-cleartext": [
+            "elb.regions.us-east-1.vpcs.vpc-c51788a1.elbs.e5eb87a04a9a1225188f56939a73d2e78232e8db.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-c51788a1.elbs.e29baca49135c16472dbf02692e9d1c882e1c803.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-c51788a1.elbs.3b6faa5c884bd3132d05d8ba18c63f6e6d348d71.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.dde5039a8c3a5beb75539a02b18d4f7620276c76.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.5bd2d9423570a16dc7c0653eff5f1e9a21d83c0d.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.ea12b9c1018a37ae8936def7d8b481cb974d9fef.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.924a890c71e2725a4bb8e0df02c521c8f3fac365.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.fa29e998b4574cb5bfe52fc58b1954fd30dbfddb.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.2c508d40ec1061c8325642759c686b05f301570f.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.2ef39ef1bfe550addc4de5a8f44d235921485fc1.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.72c3df877586f009e973ce60883e722d66fe1777.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.14d8482efc2bcb3d7d13e2801180ea4e4ea869a2.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.26dfa39eeea9d63415c81bd1e658912a3d6f1371.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.88058fbfee2dc00cbdadb0a8ed7ef39702343b8f.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.09813f92de848a9d502d367bd28fa3d2d7e90aeb.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.4da5bae5c9bfc5c975a0003372c97215b85979d2.listeners.8080",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.4da5bae5c9bfc5c975a0003372c97215b85979d2.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.6d8a8eb4c653b31de11e0ed62fdba5c878c8f18a.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.76d9aea63df92d57c71444fc89775985ab9c074d.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.d02ea55140419057fb1f8afdad11269f04d81c68.listeners.80",
+            "elb.regions.us-east-1.vpcs.vpc-9f5eb5fb.elbs.955c46f239ec065ce60800034c8ed6f042f2eb59.listeners.80"
+        ]
+    }
+}


### PR DESCRIPTION
Scout Suite flagged ELBs for listening to port 80 which accepts unsecure HTTP requests.  This is to be expected since web end points will redirect users to secure port 443 as appropriate. Disabling port 80 would prevent normal functionality.

Added exceptions for all ELBs after confirming external ELBs also listen to 443. Internal ELBs are not required to listen to 443.
