### PR TITLE
Add pull github app config to repo to keep it up to date-ish.

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,11 @@
+version: "1"
+rules:
+  - base: master
+    upstream: nccgroup:master
+    mergeMethod: merge
+    mergeUnstable: false
+    reviewers:
+      - "ifit/devops-squad-reviewers"
+    conflictReviewers:
+      - "ifit/devops-squad-reviewers"
+label: ":robot: :arrow_heading_down: pull"


### PR DESCRIPTION
Adds config file for https://github.com/apps/pull, will ping `@ifit/devops-squad-reviewers` for PRs keeping ScouteSuite up to date-ish to prevent any incompatibilities long term as we continue to leverage it.